### PR TITLE
Spring Config Server Interface

### DIFF
--- a/src/configs/config_client.py
+++ b/src/configs/config_client.py
@@ -1,0 +1,50 @@
+import json
+import requests
+import re
+import logging
+
+from ..security.authenticator import AuthenticationHandler
+from environs import Env
+
+logger = logging.getLogger(__name__)
+
+
+def parse_config(property_sources):
+    config_server_properties = {}
+    property_sources.reverse()
+
+    for property_source in property_sources:
+        config_server_properties.update(property_source['source'])
+
+    return config_server_properties
+
+
+class PythonConfigClient:
+
+    def __init__(self, auth_handler: AuthenticationHandler, env: Env):
+        self.address = env.str('config-address')
+        self.branch = env.str('branch')
+        self.profile = env.str('profile')
+        self.app_name = env.str('app-name')
+        self.profile = self.profile.replace(',', '%2C')
+        config_url = self.address + '/' + self.app_name + '/' + self.profile + '/' + self.branch
+        headers = {'X-Config-Token': auth_handler.get_auth_token()}
+
+        try:
+            logger.info('Getting the properties from the config server')
+            response = requests.get(config_url, headers=headers)
+            decoded_response = response.content.decode('utf-8')
+            property_sources = json.loads(decoded_response)['propertySources']
+            self.CONFIG_SERVER_PROPERTIES = parse_config(property_sources)
+            logger.info('Config properties have been successfully fetched')
+        except Exception as exception:
+            logger.error('Failed to fetch configs from config server' + str(exception))
+
+    def serve_value(self, key):
+        value = str(self.CONFIG_SERVER_PROPERTIES.get(key))
+        match = re.search('(?<=\${)[a-zA-Z0-9.-]*(?=})', value)
+        if match:
+            sub_key = match.group(0)
+            return value.replace('${' + sub_key + '}', str(self.CONFIG_SERVER_PROPERTIES.get(sub_key)))
+        else:
+            return value

--- a/src/configs/containers.py
+++ b/src/configs/containers.py
@@ -3,6 +3,7 @@ from environs import Env
 
 from ..services.sample_service import SampleService
 from ..security.authenticator import AuthenticationHandler
+from ..configs.config_client import PythonConfigClient
 
 
 class Container(containers.DeclarativeContainer):
@@ -14,6 +15,12 @@ class Container(containers.DeclarativeContainer):
 
     auth_handler = providers.Singleton(
         AuthenticationHandler,
+        env=env
+    )
+
+    python_config_client = providers.Singleton(
+        PythonConfigClient,
+        auth_handler=auth_handler,
         env=env
     )
 


### PR DESCRIPTION
1. PythonConfigClient class enables an interface with the Spring Config Server. The config server address, profiles to be loaded, the branch and the app_name are stored as environment variables and these are read by the config to fetch and serve values
2. The serve_value method can be used to get the values fetched from the config server by passing the key. It also supports interpolation
3. Added the python_config_client module to containers.py so that any service that needs it can use it as a dependency